### PR TITLE
Fix BAML Windows encoding issue with emoji characters

### DIFF
--- a/baml_init.py
+++ b/baml_init.py
@@ -81,7 +81,7 @@ def generate_baml(verbose=True):
             )
         
         if verbose and not debug_mode:
-            print("  ✅ BAML client generated")
+            print("  [OK] BAML client generated")  # Note: avoid emojis - they cause Windows build issues with charmap codec
         elif verbose:
             print("BAML initialization completed successfully!")
         return True

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 """Version information for rulectl."""
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"


### PR DESCRIPTION
## Summary
- Fix Windows build failures caused by Unicode emoji characters in BAML initialization
- Replace ✅ emoji with ASCII text `[OK]` to prevent `charmap` codec encoding errors
- Bump version to 0.1.3

## Problem
The BAML initialization script was using a Unicode checkmark emoji (✅) that cannot be encoded using Windows' default `charmap` codec, causing build failures on Windows CI runners with the error:
```
'charmap' codec can't encode character '\u2705' in position 2: character maps to <undefined>
```

## Solution
- Replace Unicode emoji with ASCII-compatible text `[OK]`
- Add inline comment explaining why emojis should be avoided for Windows compatibility
- Ensure all output uses only ASCII characters to maintain cross-platform compatibility

## Changes
- ✅ Fixed emoji encoding issue in `baml_init.py`
- ✅ Added explanatory comment about Windows emoji limitations
- ✅ Version bump to 0.1.3

## Test plan
- [ ] Verify Windows CI builds complete successfully
- [ ] Confirm BAML client generation works on all platforms
- [ ] Check that console output displays correctly on Windows

This addresses a critical bug that was preventing successful builds on Windows machines.

🤖 Generated with [Claude Code](https://claude.ai/code)