### PR TITLE
Fix Windows Python Unicode console output encoding issues

### DIFF
--- a/build.py
+++ b/build.py
@@ -6,6 +6,12 @@ Build script to create standalone executables using PyInstaller.
 import os
 import sys
 import platform
+
+# Fix Unicode output on Windows
+if sys.platform == "win32":
+    import io
+    sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8', errors='replace')
+    sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding='utf-8', errors='replace')
 import PyInstaller.__main__
 import shutil
 from pathlib import Path

--- a/fix_dependencies.py
+++ b/fix_dependencies.py
@@ -7,6 +7,12 @@ import subprocess
 import sys
 import os
 
+# Fix Unicode output on Windows
+if sys.platform == "win32":
+    import io
+    sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8', errors='replace')
+    sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding='utf-8', errors='replace')
+
 def run_command(cmd, description):
     """Run a command and handle errors."""
     print(f"🔧 {description}...")

--- a/test_cli.py
+++ b/test_cli.py
@@ -9,6 +9,12 @@ import tempfile
 import os
 from pathlib import Path
 
+# Fix Unicode output on Windows
+if sys.platform == "win32":
+    import io
+    sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8', errors='replace')
+    sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding='utf-8', errors='replace')
+
 
 def run_command(cmd, description=""):
     """Run a command and return result."""

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 """Version information for rulectl."""
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"


### PR DESCRIPTION
## Summary
- Fix Windows CI build failures caused by Python Unicode console output encoding issues
- Add UTF-8 encoding wrapper for stdout/stderr on Windows systems
- Preserve all emoji characters while ensuring cross-platform compatibility
- Version bump to 0.1.4

## Problem
Windows CI runners were failing when Python tried to output Unicode characters (emojis) to the console due to Windows' default `cp1252` codec limitations. The error occurred in multiple scripts:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f680' in position 0: character maps to <undefined>
```

This is a common Python/Windows encoding issue where the default console encoding can't handle Unicode characters.

## Solution
Rather than removing emojis, implement proper Unicode handling by wrapping stdout/stderr with UTF-8 encoding on Windows:

```python
# Fix Unicode output on Windows
if sys.platform == "win32":
    import io
    sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8', errors='replace')
    sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding='utf-8', errors='replace')
```

This solution:
- ✅ Preserves all emoji characters and Unicode output
- ✅ Ensures Windows compatibility
- ✅ Uses proper encoding practices
- ✅ Handles errors gracefully with 'replace' mode

## Changes
- ✅ Added Unicode fix to `build.py` (main build script)
- ✅ Added Unicode fix to `fix_dependencies.py` (dependency resolution)
- ✅ Added Unicode fix to `test_cli.py` (testing script)
- ✅ Version bump to 0.1.4

## Test plan
- [ ] Verify Windows CI builds complete successfully with Unicode output
- [ ] Confirm all emoji characters display correctly on Windows
- [ ] Check that build, dependency fix, and test scripts work on all platforms
- [ ] Validate that the encoding fix doesn't affect Unix/Linux/macOS systems

This is the proper solution for handling Python Unicode output on Windows rather than removing Unicode characters.

🤖 Generated with [Claude Code](https://claude.ai/code)