### PR TITLE
ci: Use GITHUB_TOKEN for homebrew tap automation instead of PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,7 +575,7 @@ jobs:
       - name: Trigger Homebrew tap update
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: actual-software/homebrew-tap
           event-type: new-release
           client-payload: |


### PR DESCRIPTION
## Changes

- Replace `HOMEBREW_TAP_TOKEN` with built-in `GITHUB_TOKEN` in release workflow
- Removes need for custom Personal Access Token secret
- More secure and compliant with organizational security practices
- Works because both repositories are in the same organization (actual-software)

## Benefits

✅ **Security**: Uses GitHub's built-in token instead of custom PAT
✅ **Compliance**: No need to manage additional secrets
✅ **Maintenance**: One less token to rotate/manage

## Testing

The automation will be tested on the next version release. The homebrew tap repository is already configured to handle the repository dispatch events from this workflow.

## Related

- Homebrew tap: https://github.com/actual-software/homebrew-tap
- Users will be able to install with: `brew tap actual-software/tap && brew install rulectl`