### PR TITLE
fix: Add pytest-asyncio dependency for Python tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytest-asyncio
 
       - name: Run Python tests
         run: |


### PR DESCRIPTION
## Summary
- Add pytest-asyncio to CI workflow dependencies
- Required by conftest.py in feature branches with async tests
- Fixes import errors when running Python test suite

## Test plan
- [ ] Verify Python tests run successfully on feature branches
- [ ] Check that pytest-asyncio import errors are resolved

🤖 Generated with [Claude Code](https://claude.ai/code)